### PR TITLE
fixes tests to work with granary-server changes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+**/node_modules/**
+**/bower_components/**

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": "eslint:recommended",
+  "env": {
+      "node": true,
+      "mocha": true
+  }
+}

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,6 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.network "private_network", type: "dhcp", bridge: "en1: Wi-Fi (AirPort)"
-  config.vm.network "forwarded_port", guest: 8872, host: 8872
   config.ssh.forward_agent = true
   config.vm.synced_folder ".", "/vagrant" , id: "core", :nfs => true,  :mount_options   => ['nolock,vers=3,udp']
   config.vm.provision :shell, path: "scripts/provision.sh"

--- a/granary.js
+++ b/granary.js
@@ -67,8 +67,7 @@ module.exports = function () {
           extra.password = password;
           return track.request(url, project, extra, options);
         })
-        .then(
-          function (result) {
+        .then(function () {
             log.debug('Granary request complete.');
             if (! options.server) {
               process.exit(0);

--- a/lib/password.js
+++ b/lib/password.js
@@ -34,9 +34,9 @@ module.exports = function(log) {
             });
         },
         reject: function() {
-            return new Promise(function(resolve, reject) {
+            return new Promise(function(resolve, reject) { // eslint-disable-line no-unused-vars
                 db.del('password', function(){
-                        resolve();
+                    resolve();
                 });
             });
         }

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -187,11 +187,10 @@ module.exports = function(log) {
     };
 
     Remote.granaryDone = function(start) {
-        return new Promise(function(resolve, reject) {
-
+        // TODO: can we take this promise away?
+        return new Promise(function(resolve, reject) { // eslint-disable-line no-unused-vars
             var end = Date.now();
             log.info('Granary is done in', (end - start) / 1000, 'seconds.');
-
         });
     };
 
@@ -224,14 +223,14 @@ module.exports = function(log) {
             }
         }
         log.info('\n************');
-        return new Promise(function(resolve, reject) {});
+        return new Promise(function(resolve, reject) {}); // eslint-disable-line no-unused-vars
     };
 
     Remote.serverError = function(server) {
         log.info('************');
         log.info('Granary Server not found at', server);
         log.info('************');
-        return new Promise(function(resolve, reject) {});
+        return new Promise(function(resolve, reject) {}); // eslint-disable-line no-unused-vars
     };
 
     return Remote;

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -4,160 +4,160 @@ var url = require('url');
 
 module.exports = function(log) {
 
-  var manifest = require('./manifest')(log);
-  var remote = require('./remote')(log);
-  function Startup() {}
+    var manifest = require('./manifest')(log);
+    var remote = require('./remote')(log);
 
-  Startup.log = function(options) {
-    options = options || {};
+    function Startup() {}
 
-    if (! options.log) {
+    Startup.log = function(options) {
+        options = options || {};
 
-      if (options.verbose) {
-        log.setLevel(log.levels.DEBUG);
-      } else {
-        log.setLevel(log.levels.INFO);
-      }
+        if (!options.log) {
 
-      if (options.silent) {
-        log.setLevel(log.levels.SILENT);
-        log.disabled = true;
-      }
-    }
+            if (options.verbose) {
+                log.setLevel(log.levels.DEBUG);
+            } else {
+                log.setLevel(log.levels.INFO);
+            }
 
-    log.debug('Options:', options);
-  };
+            if (options.silent) {
+                log.setLevel(log.levels.SILENT);
+                log.disabled = true;
+            }
+        }
 
-  Startup.validate = function(options) {
-    // if no --url set, try to fallback on env GRANARY_URL
-    var granaryUrl = options.url || process.env.GRANARY_URL;
+        log.debug('Options:', options);
+    };
 
-    // throw an error if --url is not set
-    if (! granaryUrl) {
-      log.error('NOTE: Set server URL with "--url=http://example.com" or GRANARY_URL=http://example.com');
-      throw new Error('Server URL not set.')
-    }
+    Startup.validate = function(options) {
+        // if no --url set, try to fallback on env GRANARY_URL
+        var granaryUrl = options.url || process.env.GRANARY_URL;
 
-    options.url = url.format(url.parse(granaryUrl));
-  };
+        // throw an error if --url is not set
+        if (!granaryUrl) {
+            log.error('NOTE: Set server URL with "--url=http://example.com" or GRANARY_URL=http://example.com');
+            throw new Error('Server URL not set.')
+        }
 
-  Startup.granaryRequest = function(url, project, extra, options) {
-    var start = Date.now();
-    var manifestEnv = manifest.detectEnvironment(extra.projectDir);
+        options.url = url.format(url.parse(granaryUrl));
+    };
 
-    if (manifestEnv.bower) {
-      var bowerData = manifest.getData(path.join(extra.projectDir, 'bower.json'));
-      project.bower.dependencies = bowerData.dependencies;
-      project.bower.devDependencies = bowerData.devDependencies;
-      project.bower.resolutions = bowerData.resolutions;
-      if (bowerData.name) {
-        project.name = bowerData.name;
-      }
-      // get .bowerrc data
-      if (fs.existsSync(path.join(extra.projectDir, '.bowerrc'))) {
-        project.bower.rc = manifest.getData(path.join(extra.projectDir, '.bowerrc'));
-      }
-    }
+    Startup.granaryRequest = function(url, project, extra, options) {
+        var start = Date.now();
+        var manifestEnv = manifest.detectEnvironment(extra.projectDir);
 
-    if (manifestEnv.npm) {
-      var npmData = manifest.getData(path.join(extra.projectDir, 'package.json'));
-      project.npm.dependencies = npmData.dependencies;
-      project.npm.devDependencies = npmData.devDependencies;
+        if (manifestEnv.bower) {
+            var bowerData = manifest.getData(path.join(extra.projectDir, 'bower.json'));
+            project.bower.dependencies = bowerData.dependencies;
+            project.bower.devDependencies = bowerData.devDependencies;
+            project.bower.resolutions = bowerData.resolutions;
+            if (bowerData.name) {
+                project.name = bowerData.name;
+            }
+            // get .bowerrc data
+            if (fs.existsSync(path.join(extra.projectDir, '.bowerrc'))) {
+                project.bower.rc = manifest.getData(path.join(extra.projectDir, '.bowerrc'));
+            }
+        }
 
-      if (fs.existsSync(path.join(extra.projectDir, 'npm-shrinkwrap.json'))) {
-        project.npm.shrinkwrap = manifest.getData(path.join(extra.projectDir, 'npm-shrinkwrap.json'));
-      }
+        if (manifestEnv.npm) {
+            var npmData = manifest.getData(path.join(extra.projectDir, 'package.json'));
+            project.npm.dependencies = npmData.dependencies;
+            project.npm.devDependencies = npmData.devDependencies;
 
-      if (npmData.name) {
-        // NPM project name is used over Bower, unless we Bower only
-        project.name = npmData.name;
-      }
-    }
+            if (fs.existsSync(path.join(extra.projectDir, 'npm-shrinkwrap.json'))) {
+                project.npm.shrinkwrap = manifest.getData(path.join(extra.projectDir, 'npm-shrinkwrap.json'));
+            }
 
-    log.debug('Project Configuration:', project);
-    log.debug('Server Configuration:', url);
+            if (npmData.name) {
+                // NPM project name is used over Bower, unless we Bower only
+                project.name = npmData.name;
+            }
+        }
 
-    // check if this granary is available
-    remote.granaryCheck(url, project, extra)
-      .then(
-      function (granary) {
-        // granary server response
+        log.debug('Project Configuration:', project);
+        log.debug('Server Configuration:', url);
 
-        // if wanted to create, then don't download
-        if (options.action === 'create') {
-          // report the status
-          return remote.granaryStatus(granary, url, extra.create);
-        } else {
-          // else just want to download the bundle
-          if (granary.available) {
-            // download the Freight Bundle if available
-            var downloadOpts = {
-              production: extra.production
-            };
-            return remote.granaryDownload(project.name, url, granary.hash, downloadOpts)
-              .then(function (bundleFile) {
-                return remote.granaryExtract(bundleFile);
-              }).then(function (bundleFile) {
-                return remote.granaryCleanup(bundleFile);
-              }).then(function () {
-                return remote.granaryPostExtract();
-              }).then(
-              function () {
-                return remote.granaryDone(start);
-              },
-              function (err) {
-                log.error(err);
-                throw err;
-              }
+        // check if this granary is available
+        remote.granaryCheck(url, project, extra)
+            .then(
+                function(granary) {
+                    // granary server response
+
+                    // if wanted to create, then don't download
+                    if (options.action === 'create') {
+                        // report the status
+                        return remote.granaryStatus(granary, url, extra.create);
+                    } else {
+                        // else just want to download the bundle
+                        if (granary.available) {
+                            // download the Freight Bundle if available
+                            var downloadOpts = {
+                                production: extra.production
+                            };
+                            return remote.granaryDownload(project.name, url, granary.hash, downloadOpts)
+                                .then(function(bundleFile) {
+                                    return remote.granaryExtract(bundleFile);
+                                }).then(function(bundleFile) {
+                                    return remote.granaryCleanup(bundleFile);
+                                }).then(function() {
+                                    return remote.granaryPostExtract();
+                                }).then(
+                                    function() {
+                                        return remote.granaryDone(start);
+                                    },
+                                    function(err) {
+                                        log.error(err);
+                                        throw err;
+                                    }
+                                );
+                        } else if (granary.available === false) {
+                            // otherwise granary is not available
+                            return remote.granaryStatus(granary, url, extra.create);
+                        } else {
+                            // no response
+                            return remote.serverError(url);
+                        }
+                    }
+
+                })
+            .then(function() {
+                    log.debug('Granary request complete.');
+                    if (!options.server) {
+                        process.exit(0);
+                    }
+                },
+                function(err) {
+                    log.error(err);
+                    if (!options.server) {
+                        process.exit(1);
+                    }
+                }
             );
-          } else if (granary.available === false) {
-            // otherwise granary is not available
-            return remote.granaryStatus(granary, url, extra.create);
-          } else {
-            // no response
-            return remote.serverError(url);
-          }
+    };
+
+    /**
+     * Detect if this is a production bundle request
+     * @param {Object} options
+     */
+    Startup.detectProduction = function(options) {
+        var production = false;
+
+        if (process.env.NODE_ENV && process.env.NODE_ENV === 'production') {
+            production = true;
         }
 
-      })
-      .then(
-        function (result) {
-          log.debug('Granary request complete.');
-          if (! options.server) {
-            process.exit(0);
-          }
-        },
-        function (err) {
-          log.error(err);
-          if (! options.server) {
-            process.exit(1);
-          }
+        // CLI option overrides NODE_ENV
+        if (options.production === false) {
+            production = false;
         }
-      );
-  };
 
-  /**
-   * Detect if this is a production bundle request
-   * @param {Object} options
-   */
-  Startup.detectProduction = function(options) {
-    var production = false;
+        if (options.production === true) {
+            production = true;
+        }
 
-    if (process.env.NODE_ENV && process.env.NODE_ENV === 'production') {
-      production = true;
-    }
+        return production;
+    };
 
-    // CLI option overrides NODE_ENV
-    if (options.production === false) {
-      production = false;
-    }
-
-    if (options.production === true) {
-      production = true;
-    }
-
-    return production;
-  };
-
-  return Startup;
+    return Startup;
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "granary": "bin/granary"
   },
   "scripts": {
-      "test": "redis-cli flushall; rm -rf node_modules/granary-server/storage/**;./node_modules/mocha/bin/mocha test/index.js --reporter=spec"
+    "test": "redis-cli flushall; rm -rf node_modules/granary-server/storage/**;./node_modules/eslint/bin/eslint.js .;./node_modules/mocha/bin/mocha test/index.js --reporter=spec"
   },
   "description": "Dependency Bundling for NPM and Bower",
   "homepage": "https://github.com/gabrielcsapo/granary",
@@ -22,6 +22,7 @@
   "main": "./granary",
   "dependencies": {
     "bluebird": "^3.3.5",
+    "eslint": "^2.9.0",
     "file-size": "^1.0.0",
     "leveldown": "^1.4.5",
     "levelup": "^1.3.1",

--- a/test/create.js
+++ b/test/create.js
@@ -5,12 +5,11 @@ var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
 var assert = require('chai').assert;
 
-var executable = path.resolve(__dirname + '/../bin/granary');
-var currentDir = process.cwd();
+var executable = path.resolve(require.resolve('granary'), '..', 'bin', 'granary');
 
 describe('create', function() {
     this.timeout(3000000);
-    
+
     it('should ask for password, fail on wrong password', function(done) {
         process.env.GRANARY_PASSWORD = 'wrong';
 
@@ -21,7 +20,7 @@ describe('create', function() {
             child.kill('SIGINT');
         });
 
-        child.on('exit', function(data) {
+        child.on('exit', function() {
             done();
         });
 
@@ -30,7 +29,7 @@ describe('create', function() {
     it('should ask for password, fail on no password', function(done) {
         var child = spawn(executable, ['create', '-u=http://localhost:8872']);
 
-        child.stdout.on("data", function(data) {
+        child.stdout.on("data", function() {
             child.stdin.write('\n');
             child.stdin.end();
         });
@@ -40,46 +39,42 @@ describe('create', function() {
             child.kill('SIGINT');
         });
 
-        child.on('exit', function(data) {
+        child.on('exit', function() {
             done();
         });
 
     });
 
     it('should work with npm', function(done) {
-        process.env.GRANARY_PASSWORD = 'testing';
+        process.env.GRANARY_PASSWORD = process.CORRECT_PASSWORD;
 
         var directory = path.resolve(__dirname + '/fixtures/npm');
         var cmd = executable + ' create -u=http://localhost:8872 --directory=' + directory
 
-        exec(cmd, function(error, stdout, stderr) {
+        exec(cmd, function(error, _stdout, _stderr) {
             process.chdir(directory);
-            assert.equal(stderr, '');
             var output =
                 '************\n\n' +
                 'Granary Server will now generate a bundle.\n' +
                 'Monitor your Granary at http://localhost:8872/granary/active\n\n' +
                 '************\n';
-            assert.equal(stdout, output);
+            assert.equal(_stderr, '');
+            assert.equal(_stdout, output);
 
             var stdout = [];
             var finished = false;
 
             var check = function() {
-                if(stdout.indexOf('Extracting bundle...\n') > -1) {
-                    console.log('check');
-                    // Wait for bundle to extract completely
-                    setTimeout(function() {
-                        assert.ok(fs.existsSync(path.resolve(directory, 'node_modules/rimraf/package.json')));
-                        assert.ok(fs.existsSync(path.resolve(directory, 'node_modules/inherits/package.json')));
-                        assert.notOk(fs.existsSync(path.resolve(directory,'bower_components')));
-                        assert.notOk(fs.existsSync(path.resolve(directory,'bower.json')));
-                        assert.notOk(fs.existsSync(path.resolve(directory,'.bowerrc')));
-                        assert.notOk(fs.existsSync(path.resolve(directory,'node_modules/mocha')));
-                        console.log(stdout);
-                        done();
-                    }, 1000);
-                }
+                // Wait for bundle to extract completely
+                setTimeout(function() {
+                    assert.ok(fs.existsSync(path.resolve(directory, 'node_modules/rimraf/package.json')));
+                    assert.ok(fs.existsSync(path.resolve(directory, 'node_modules/inherits/package.json')));
+                    assert.notOk(fs.existsSync(path.resolve(directory,'bower_components')));
+                    assert.notOk(fs.existsSync(path.resolve(directory,'bower.json')));
+                    assert.notOk(fs.existsSync(path.resolve(directory,'.bowerrc')));
+                    assert.notOk(fs.existsSync(path.resolve(directory,'node_modules/mocha')));
+                    done();
+                }, 1000);
             }
 
             var run = function() {
@@ -100,10 +95,10 @@ describe('create', function() {
                 });
 
                 child.stderr.on("data", function(data) {
-                    assert.equal(stderr, '');
+                    assert.equal(data, '');
                 });
 
-                child.on('exit', function(data) {
+                child.on('exit', function() {
                     if(!finished) {
                         setTimeout(function() {
                             run();
@@ -122,36 +117,32 @@ describe('create', function() {
     });
 
     it('should work with bower', function(done) {
-        process.env.GRANARY_PASSWORD = 'testing';
+        process.env.GRANARY_PASSWORD = process.CORRECT_PASSWORD;
 
         var directory = path.resolve(__dirname + '/fixtures/bower');
         var cmd = executable + ' create -u=http://localhost:8872 --directory=' + directory
 
-        exec(cmd, function(error, stdout, stderr) {
+        exec(cmd, function(error, _stdout, _stderr) {
             process.chdir(directory);
-            assert.equal(stderr, '');
             var output =
                 '************\n\n' +
                 'Granary Server will now generate a bundle.\n' +
                 'Monitor your Granary at http://localhost:8872/granary/active\n\n' +
                 '************\n';
-            assert.equal(stdout, output);
+            assert.equal(_stderr, '');
+            assert.equal(_stdout, output);
 
             var stdout = [];
             var finished = false;
 
             var check = function() {
-                if(stdout.indexOf('Extracting bundle...\n') > -1) {
-                    console.log('check');
-                    // Wait for bundle to extract completely
-                    setTimeout(function() {
-                        assert.ok(fs.existsSync(path.resolve(directory, 'app/bower_components')));
-                        assert.ok(fs.existsSync(path.resolve(directory, 'app/bower_components/moment/moment.js'), 'moment should exist'));
-                        assert.ok(fs.existsSync(path.resolve(directory, 'bower.json')));
-                        console.log(stdout);
-                        done();
-                    }, 1000);
-                }
+                // Wait for bundle to extract completely
+                setTimeout(function() {
+                    assert.ok(fs.existsSync(path.resolve(directory, 'app/bower_components')));
+                    assert.ok(fs.existsSync(path.resolve(directory, 'app/bower_components/moment/moment.js'), 'moment should exist'));
+                    assert.ok(fs.existsSync(path.resolve(directory, 'bower.json')));
+                    done();
+                }, 2000);
             }
 
             var run = function() {
@@ -172,10 +163,10 @@ describe('create', function() {
                 });
 
                 child.stderr.on("data", function(data) {
-                    assert.equal(stderr, '');
+                    assert.equal(data, '');
                 });
 
-                child.on('exit', function(data) {
+                child.on('exit', function() {
                     if(!finished) {
                         setTimeout(function() {
                             run();
@@ -194,41 +185,35 @@ describe('create', function() {
     });
 
     it('should work with npm+bower', function(done) {
-        process.env.GRANARY_PASSWORD = 'testing';
+        process.env.GRANARY_PASSWORD = process.CORRECT_PASSWORD;
 
         var directory = path.resolve(__dirname + '/fixtures/npm+bower');
         var cmd = executable + ' create -u=http://localhost:8872 --directory=' + directory
 
-        exec(cmd, function(error, stdout, stderr) {
+        exec(cmd, function(error, _stdout, _stderr) {
             process.chdir(directory);
-            assert.equal(stderr, '');
             var output =
                 '************\n\n' +
                 'Granary Server will now generate a bundle.\n' +
                 'Monitor your Granary at http://localhost:8872/granary/active\n\n' +
                 '************\n';
-            assert.equal(stdout, output);
+            assert.equal(_stderr, '');
+            assert.equal(_stdout, output);
 
             var stdout = [];
             var finished = false;
 
             var check = function() {
-                if(stdout.indexOf('Extracting bundle...\n') > -1) {
-                    console.log('check');
-                    console.log(stdout);
-                    // Wait for bundle to extract completely
-                    setTimeout(function() {
-                        console.log(stdout);
-                        assert.ok(fs.existsSync(path.resolve(directory, 'app/bower_components')));
-                        assert.ok(fs.existsSync(path.resolve(directory, 'app/bower_components/moment/moment.js'), 'moment should exist'));
-                        assert.ok(fs.existsSync(path.resolve(directory, 'bower.json')));
-                        assert.ok(fs.existsSync(path.resolve(directory, 'node_modules')));
-                        assert.ok(fs.existsSync(path.resolve(directory, 'node_modules/rimraf/package.json')));
-                        assert.ok(fs.existsSync(path.resolve(directory, 'node_modules/inherits/package.json')));
-                        console.log(stdout);
-                        done();
-                    }, 3000);
-                }
+                // Wait for bundle to extract completely
+                setTimeout(function() {
+                    assert.ok(fs.existsSync(path.resolve(directory, 'app/bower_components')));
+                    assert.ok(fs.existsSync(path.resolve(directory, 'app/bower_components/moment/moment.js'), 'moment should exist'));
+                    assert.ok(fs.existsSync(path.resolve(directory, 'bower.json')));
+                    assert.ok(fs.existsSync(path.resolve(directory, 'node_modules')));
+                    assert.ok(fs.existsSync(path.resolve(directory, 'node_modules/rimraf/package.json')));
+                    assert.ok(fs.existsSync(path.resolve(directory, 'node_modules/inherits/package.json')));
+                    done();
+                }, 3000);
             }
 
             var run = function() {
@@ -249,10 +234,10 @@ describe('create', function() {
                 });
 
                 child.stderr.on("data", function(data) {
-                    assert.equal(stderr, '');
+                    assert.equal(data, '');
                 });
 
-                child.on('exit', function(data) {
+                child.on('exit', function() {
                     if(!finished) {
                         setTimeout(function() {
                             run();

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var fs = require('fs');
 var spawn = require('child_process').spawn;
 
 var cli = '';
@@ -14,13 +15,14 @@ describe('granary-server', function() {
         });
         cli.stdout.on('data', function(data) {
             var message = data.toString('utf8');
-            console.log(message);
-            if(message.indexOf('INFO freight-server: Granary Server is now running port 8872') > -1) {
+            if(message.indexOf('INFO granary-server: Granary Server is now running port 8872') > -1) {
+                var config = JSON.parse(fs.readFileSync(path.resolve('node_modules', 'granary-server', 'config', 'dev.json')));
+                process.CORRECT_PASSWORD = config.password;
                 done();
             }
         });
         cli.stderr.on('data', function (data) {
-            console.log('err data: ' + data);
+            console.log('err data: ' + data); // eslint-disable-line no-console
             cli.kill();
         });
     })


### PR DESCRIPTION
fixes #15 

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ killall node;npm test

> granary@0.0.4 test /vagrant
> redis-cli flushall; rm -rf node_modules/granary-server/storage/**;./node_modules/eslint/bin/eslint.js .;./node_modules/mocha/bin/mocha test/index.js --reporter=spec

OK

  granary-server
    cli
      ✓ should error with no url set (595ms)
      ✓ should not error with url set (445ms)
      ✓ should not error with GRANARY_URL set (428ms)
      ✓ should be --silent (412ms)
      ✓ should be --silent (417ms)
      ✓ should show help at all cost (71ms)
      ✓ should show verbose output (460ms)
    create
      ✓ should ask for password, fail on wrong password (419ms)
      ✓ should ask for password, fail on no password (423ms)
      ✓ should work with npm (6022ms)
      ✓ should work with bower (13302ms)
      ✓ should work with npm+bower (15431ms)

  12 passing (40s)
```
