### PR TITLE
allows for the inclusion of a .granaryrc.json in project directory

### DIFF
--- a/lib/startup.js
+++ b/lib/startup.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var fs = require('fs');
+// TODO: do we need this library?
 var url = require('url');
 
 module.exports = function(log) {
@@ -34,16 +35,17 @@ module.exports = function(log) {
         // check .granaryrc
         // if none, check --url set, try to fallback on env GRANARY_URL
         // use the directory option if presented if not continue
+        var granaryUrl;
         var granaryrcPath = path.resolve(options.directory || process.cwd(), '.granaryrc.json');
         try {
             var granaryrc = fs.readFileSync(granaryrcPath, 'utf8');
             if (granaryrc && JSON.parse(granaryrc).url) {
                 // .granaryrc options can be overriden by environmental variables
-                var granaryUrl = JSON.parse(granaryrc).url || options.url || process.env.GRANARY_URL;
+                granaryUrl = JSON.parse(granaryrc).url || options.url || process.env.GRANARY_URL;
             }
         } catch(ex) {
             log.debug(ex);
-            var granaryUrl = options.url || process.env.GRANARY_URL;
+            granaryUrl = options.url || process.env.GRANARY_URL;
         }
 
         // throw an error if --url is not set

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -29,9 +29,22 @@ module.exports = function(log) {
         log.debug('Options:', options);
     };
 
+    // TODO: cleanup
     Startup.validate = function(options) {
-        // if no --url set, try to fallback on env GRANARY_URL
-        var granaryUrl = options.url || process.env.GRANARY_URL;
+        // check .granaryrc
+        // if none, check --url set, try to fallback on env GRANARY_URL
+        // use the directory option if presented if not continue
+        var granaryrcPath = path.resolve(options.directory || process.cwd(), '.granaryrc.json');
+        try {
+            var granaryrc = fs.readFileSync(granaryrcPath, 'utf8');
+            if (granaryrc && JSON.parse(granaryrc).url) {
+                // .granaryrc options can be overriden by environmental variables
+                var granaryUrl = JSON.parse(granaryrc).url || options.url || process.env.GRANARY_URL;
+            }
+        } catch(ex) {
+            log.debug(ex);
+            var granaryUrl = options.url || process.env.GRANARY_URL;
+        }
 
         // throw an error if --url is not set
         if (!granaryUrl) {

--- a/test/create.js
+++ b/test/create.js
@@ -7,6 +7,8 @@ var assert = require('chai').assert;
 
 var executable = path.resolve(require.resolve('granary'), '..', 'bin', 'granary');
 
+// TODO: refactor boilerplate code?
+
 describe('create', function() {
     this.timeout(3000000);
 
@@ -95,7 +97,7 @@ describe('create', function() {
                 });
 
                 child.stderr.on("data", function(data) {
-                    assert.equal(data, '');
+                    assert.equal(data.toString('utf8'), '');
                 });
 
                 child.on('exit', function() {
@@ -163,7 +165,7 @@ describe('create', function() {
                 });
 
                 child.stderr.on("data", function(data) {
-                    assert.equal(data, '');
+                    assert.equal(data.toString('utf8'), '');
                 });
 
                 child.on('exit', function() {
@@ -177,7 +179,7 @@ describe('create', function() {
                 });
             };
 
-            rimraf(path.resolve(directory, 'app/bower_components'), function() {
+            rimraf(path.resolve(directory, 'app'), function() {
                 run();
             });
 
@@ -234,7 +236,7 @@ describe('create', function() {
                 });
 
                 child.stderr.on("data", function(data) {
-                    assert.equal(data, '');
+                    assert.equal(data.toString('utf8'), '');
                 });
 
                 child.on('exit', function() {
@@ -262,16 +264,14 @@ describe('create', function() {
 
         var directory = path.resolve(__dirname + '/fixtures/granaryrc');
 
-        var child = spawn(executable, ['create'], {
-            cwd: directory
-        });
+        var cmd = executable + ' create --directory=' + directory
 
-        child.stderr.on('data', function(data) {
-            assert.equal(data.toString('utf8'), 'NOTE: Set server URL with "--url=http://example.com" or GRANARY_URL=http://example.com\n');
-            child.kill('SIGINT');
-        });
-
-        child.on('exit', function() {
+        exec(cmd, {
+          cwd: directory
+        }, function(error, stdout, stderr) {
+            process.chdir(directory);
+            assert.equal(stdout, '');
+            assert.ok(stderr.toString('utf8').indexOf('NOTE: Set server URL with "--url=http://example.com" or GRANARY_URL=http://example.com\n') > -1);
             done();
         });
 
@@ -283,7 +283,9 @@ describe('create', function() {
         var directory = path.resolve(__dirname + '/fixtures/npm+granaryrc');
         var cmd = executable + ' create --directory=' + directory
 
-        exec(cmd, function(error, _stdout, _stderr) {
+        exec(cmd, {
+          cwd: directory
+        }, function(error, _stdout, _stderr) {
             process.chdir(directory);
             var output =
                 '************\n\n' +
@@ -324,7 +326,7 @@ describe('create', function() {
                 });
 
                 child.stderr.on("data", function(data) {
-                    assert.equal(data, '');
+                    assert.equal(data.toString('utf8'), '');
                 });
 
                 child.on('exit', function() {

--- a/test/fixtures/granaryrc/package.json
+++ b/test/fixtures/granaryrc/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "sample-project-granaryrc",
+  "dependencies": {
+    "inherits": "2"
+  },
+  "devDependencies": {
+    "rimraf": "1.x"
+  }
+}

--- a/test/fixtures/npm+granaryrc/.gitignore
+++ b/test/fixtures/npm+granaryrc/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+bower_components
+*.log

--- a/test/fixtures/npm+granaryrc/.granaryrc.json
+++ b/test/fixtures/npm+granaryrc/.granaryrc.json
@@ -1,0 +1,3 @@
+{
+    "url": "http://localhost:8872"
+}

--- a/test/fixtures/npm+granaryrc/package.json
+++ b/test/fixtures/npm+granaryrc/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "sample-project-granaryrc",
+  "dependencies": {
+    "inherits": "2"
+  },
+  "devDependencies": {
+    "rimraf": "1.x"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var spawn = require('child_process').spawn;
 
 var cli = '';
 
-describe('granary-server', function() {
+describe('granary', function() {
 
     before(function(done) {
         this.timeout(50000);


### PR DESCRIPTION
added tests to support this feature
fixes #8 

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ killall node; npm test;

> granary@0.0.4 test /vagrant
> redis-cli flushall; rm -rf node_modules/granary-server/storage/**;./node_modules/eslint/bin/eslint.js .;./node_modules/mocha/bin/mocha test/index.js --reporter=spec

OK


  granary
    cli
      ✓ should error with no url set (434ms)
      ✓ should not error with url set (480ms)
      ✓ should not error with GRANARY_URL set (474ms)
      ✓ should be --silent (445ms)
      ✓ should be --silent (436ms)
      ✓ should show help at all cost (73ms)
      ✓ should show verbose output (452ms)
    create
      ✓ should ask for password, fail on wrong password (430ms)
      ✓ should ask for password, fail on no password (443ms)
      ✓ should work with npm (6339ms)
      ✓ should work with bower (11415ms)
      ✓ should work with npm+bower (15793ms)
      ✓ should fail a blank .granaryrc file (465ms)
      ✓ should work with npm with a .granaryrc file (8319ms)


  14 passing (48s)
```
